### PR TITLE
chore(codeowners): stop CODEOWNERS-driven review assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,0 @@
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
-*       @alextmeyer @jeremy-eb @eb-brandonhamric @jasper-eb @ebbeck @gray-eb @rainu-evb


### PR DESCRIPTION
Removing CODEOWNERS-driven automatic review assignment / enforcement org-wide.

- The machine-user (`@eventbritebuild`) ownership of `CHANGELOG.txt` and `*/version.*` is intentionally retained: it drives the version-tag → CodeArtifact/ECR publish → auto-merge workflow for legacy Python libs/services.
- All other owner rules are removed; files with no machine-user line are deleted.
- CODEOWNERS-only change, no code changes.

Branch protection `require_code_owner_reviews` is being disabled on the default branch in tandem (approval count unchanged), so this PR is mergeable on a normal approval.